### PR TITLE
Channel batching

### DIFF
--- a/cmd/filter.go
+++ b/cmd/filter.go
@@ -16,17 +16,19 @@ func filterFunction(c *cli.Context) error {
 	extractor := BuildExtractorFromArguments(c)
 	readChan := extractor.ReadChan()
 	for {
-		match, more := <-readChan
+		matchBatch, more := <-readChan
 		if !more {
 			break
 		}
-		if writeLines {
-			fmt.Printf("%d: ", match.LineNumber)
-		}
-		if !customExtractor {
-			fmt.Println(color.WrapIndices(match.Line, match.Indices[2:]))
-		} else {
-			fmt.Println(match.Extracted)
+		for _, match := range matchBatch {
+			if writeLines {
+				fmt.Printf("%d: ", match.LineNumber)
+			}
+			if !customExtractor {
+				fmt.Println(color.WrapIndices(match.Line, match.Indices[2:]))
+			} else {
+				fmt.Println(match.Extracted)
+			}
 		}
 	}
 	WriteExtractorSummary(extractor)

--- a/cmd/helpers/extractorBuilder.go
+++ b/cmd/helpers/extractorBuilder.go
@@ -122,10 +122,11 @@ func BuildExtractorFromArguments(c *cli.Context) *extractor.Extractor {
 	gunzip := c.Bool("gunzip")
 	batchSize := c.Int("batch")
 	config := extractor.Config{
-		Posix:   c.Bool("posix"),
-		Regex:   c.String("match"),
-		Extract: c.String("extract"),
-		Workers: c.Int("workers"),
+		Posix:     c.Bool("posix"),
+		Regex:     c.String("match"),
+		Extract:   c.String("extract"),
+		Workers:   c.Int("workers"),
+		BatchSize: batchSize,
 	}
 
 	ignoreSlice := c.StringSlice("ignore")

--- a/cmd/helpers/extractorBuilder.go
+++ b/cmd/helpers/extractorBuilder.go
@@ -122,11 +122,10 @@ func BuildExtractorFromArguments(c *cli.Context) *extractor.Extractor {
 	gunzip := c.Bool("gunzip")
 	batchSize := c.Int("batch")
 	config := extractor.Config{
-		Posix:     c.Bool("posix"),
-		Regex:     c.String("match"),
-		Extract:   c.String("extract"),
-		Workers:   c.Int("workers"),
-		BatchSize: batchSize,
+		Posix:   c.Bool("posix"),
+		Regex:   c.String("match"),
+		Extract: c.String("extract"),
+		Workers: c.Int("workers"),
 	}
 
 	ignoreSlice := c.StringSlice("ignore")

--- a/cmd/helpers/updatingAggregator.go
+++ b/cmd/helpers/updatingAggregator.go
@@ -55,12 +55,14 @@ PROCESSING_LOOP:
 		select {
 		case <-exitSignal:
 			break PROCESSING_LOOP
-		case match, more := <-reader:
+		case matchBatch, more := <-reader:
 			if !more {
 				break PROCESSING_LOOP
 			}
 			outputMutex.Lock()
-			aggregator.Sample(match.Extracted)
+			for _, match := range matchBatch {
+				aggregator.Sample(match.Extracted)
+			}
 			outputMutex.Unlock()
 			hasUpdates.Store(true)
 		}

--- a/pkg/expressions/funcsStrings.go
+++ b/pkg/expressions/funcsStrings.go
@@ -101,7 +101,7 @@ func kfBytesize(args []KeyBuilderStage) KeyBuilderStage {
 			labelIdx++
 		}
 
-		return fmt.Sprintf("%d %s", val, byteSizes[labelIdx])
+		return strconv.Itoa(val) + " " + byteSizes[labelIdx]
 	})
 }
 

--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -18,12 +18,11 @@ type Match struct {
 
 // Config for the extractor
 type Config struct {
-	Posix     bool      // Posix parse regex
-	Regex     string    // Regex to find matches
-	Extract   string    // Extract these values from regex (expression)
-	Workers   int       // Workers to parse regex
-	BatchSize int       // Size of each read batch
-	Ignore    IgnoreSet // Ignore these truthy expressions
+	Posix   bool      // Posix parse regex
+	Regex   string    // Regex to find matches
+	Extract string    // Extract these values from regex (expression)
+	Workers int       // Workers to parse regex
+	Ignore  IgnoreSet // Ignore these truthy expressions
 }
 
 type Extractor struct {
@@ -128,15 +127,15 @@ func New(inputBatch <-chan []string, config *Config) (*Extractor, error) {
 					break
 				}
 
-				matchBatch := make([]Match, 0, config.BatchSize)
+				var matchBatch []Match
 				for _, s := range batch {
 					match := extractor.processLineSync(s)
 					if match != nil {
-						matchBatch = append(matchBatch, *match)
-						if len(matchBatch) >= config.BatchSize {
-							extractor.readChan <- matchBatch
-							matchBatch = make([]Match, 0, config.BatchSize)
+						if matchBatch == nil {
+							// Initialize to expected cap (only if we have any matches)
+							matchBatch = make([]Match, 0, len(batch))
 						}
+						matchBatch = append(matchBatch, *match)
 					}
 				}
 				if len(matchBatch) > 0 {

--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -101,7 +101,7 @@ func (s *Extractor) processLineSync(line string) {
 }
 
 // New an extractor from an input channel
-func New(input <-chan string, config *Config) (*Extractor, error) {
+func New(inputBatch <-chan []string, config *Config) (*Extractor, error) {
 	compiledExpression, err := expressions.NewKeyBuilder().Compile(config.Extract)
 	if err != nil {
 		return nil, err
@@ -121,11 +121,13 @@ func New(input <-chan string, config *Config) (*Extractor, error) {
 		wg.Add(1)
 		go func() {
 			for {
-				s, more := <-input
+				batch, more := <-inputBatch
 				if !more {
 					break
 				}
-				extractor.processLineSync(s)
+				for _, s := range batch {
+					extractor.processLineSync(s)
+				}
 			}
 			wg.Done()
 		}()

--- a/pkg/extractor/ioHelpers.go
+++ b/pkg/extractor/ioHelpers.go
@@ -10,7 +10,7 @@ type semiLock struct{}
 
 // CombineChannels combines multiple string channels into a single (unordered)
 //  string channel
-func CombineChannels(channels ...<-chan string) <-chan string {
+func CombineChannels(channels ...<-chan []string) <-chan []string {
 	if channels == nil {
 		return nil
 	}
@@ -18,12 +18,12 @@ func CombineChannels(channels ...<-chan string) <-chan string {
 		return channels[0]
 	}
 
-	out := make(chan string)
+	out := make(chan []string)
 	var wg sync.WaitGroup
 
 	for _, c := range channels {
 		wg.Add(1)
-		go func(subchan <-chan string) {
+		go func(subchan <-chan []string) {
 			for {
 				s, more := <-subchan
 				if !more {
@@ -45,8 +45,8 @@ func CombineChannels(channels ...<-chan string) <-chan string {
 
 // ConvertReaderToStringChan converts an io.reader to a string channel
 //  where it's separated by a new-line
-func ConvertReaderToStringChan(reader io.ReadCloser) <-chan string {
-	out := make(chan string)
+func ConvertReaderToStringChan(reader io.ReadCloser) <-chan []string {
+	out := make(chan []string)
 	scanner := bufio.NewScanner(reader)
 	bigBuf := make([]byte, 512*1024)
 	scanner.Buffer(bigBuf, len(bigBuf))
@@ -54,7 +54,7 @@ func ConvertReaderToStringChan(reader io.ReadCloser) <-chan string {
 	go func() {
 		defer reader.Close()
 		for scanner.Scan() {
-			out <- scanner.Text()
+			out <- []string{scanner.Text()} // TODO: Batching
 		}
 		close(out)
 	}()

--- a/pkg/extractor/ioHelpers.go
+++ b/pkg/extractor/ioHelpers.go
@@ -6,8 +6,6 @@ import (
 	"sync"
 )
 
-type semiLock struct{}
-
 // CombineChannels combines multiple string channels into a single (unordered)
 //  string channel
 func CombineChannels(channels ...<-chan []string) <-chan []string {

--- a/pkg/extractor/ioHelpers_test.go
+++ b/pkg/extractor/ioHelpers_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestCombiningChannels(t *testing.T) {
-	c1 := make(chan string)
-	c2 := make(chan string)
+	c1 := make(chan []string)
+	c2 := make(chan []string)
 
 	combined := CombineChannels(c1, c2)
-	c1 <- "a"
-	c2 <- "b"
-	assert.Equal(t, "a", <-combined)
-	assert.Equal(t, "b", <-combined)
+	c1 <- []string{"a"}
+	c2 <- []string{"b"}
+	assert.Equal(t, []string{"a"}, <-combined)
+	assert.Equal(t, []string{"b"}, <-combined)
 
 	close(c1)
 	close(c2)


### PR DESCRIPTION
More than doubles the performance of cpu and user time

```
# Before any optimization
0 B 200             976,871    ||||||||||||||||||||||||||||||||||||||||||||||||||
1 KB 200            6,153      
0 B 404             6,020      
1 MB 200            5,572      
2 MB 200            3,780 
Matched: 1,131,354 / 3,638,594
Groups:  549

real	0m2.315s
user	0m7.572s
sys	0m0.128s


# After genercizing towards batching:
Matched: 1,131,354 / 3,638,594
Groups:  549

real	0m2.464s
user	0m8.004s
sys	0m0.168s

# After batching input IO
Matched: 1,131,354 / 3,638,594
Groups:  549

real	0m2.213s
user	0m6.736s
sys	0m0.088s

# Batching extraction
Matched: 1,131,354 / 3,638,594
Groups:  549

real	0m1.157s
user	0m6.020s
sys	0m0.096s

```