### PR TITLE
Readahead

### DIFF
--- a/pkg/extractor/extractor_test.go
+++ b/pkg/extractor/extractor_test.go
@@ -1,0 +1,37 @@
+package extractor
+
+import (
+	"regexp"
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type StringHeader struct {
+	Data unsafe.Pointer
+	Len  int
+}
+
+func TestSliceAssumptions(t *testing.T) {
+	b := []byte("hello")
+	z := b[1:]
+	sr := (*string)(unsafe.Pointer(&z))
+	b[1] = 'a'
+	assert.Equal(t, "allo", *sr)
+}
+
+func BenchmarkRegexWithString(b *testing.B) {
+	r := regexp.MustCompile("a(.*)")
+	for n := 0; n < b.N; n++ {
+		r.FindStringSubmatchIndex("abcdefg")
+	}
+}
+
+func BenchmarkRegexWithBytes(b *testing.B) {
+	r := regexp.MustCompile("a(.*)")
+	val := []byte("abcdefg")
+	for n := 0; n < b.N; n++ {
+		r.FindSubmatchIndex(val)
+	}
+}

--- a/pkg/extractor/ioHelpers.go
+++ b/pkg/extractor/ioHelpers.go
@@ -58,13 +58,8 @@ func ConvertReaderToStringChan(reader io.ReadCloser, batchSize int) <-chan []BSt
 
 func SyncReadAheadToBatchChannel(readahead *readahead.ReadAhead, batchSize int, out chan<- []BString) {
 	batch := make([]BString, 0, batchSize)
-	for {
-		b := readahead.ReadLine()
-		if b == nil {
-			break
-		}
-
-		batch = append(batch, b)
+	for readahead.Scan() {
+		batch = append(batch, readahead.Bytes())
 		if len(batch) >= batchSize {
 			out <- batch
 			batch = make([]BString, 0, batchSize)

--- a/pkg/extractor/ioHelpers.go
+++ b/pkg/extractor/ioHelpers.go
@@ -3,12 +3,13 @@ package extractor
 import (
 	"bufio"
 	"io"
+	"rare/pkg/readahead"
 	"sync"
 )
 
 // CombineChannels combines multiple string channels into a single (unordered)
 //  string channel
-func CombineChannels(channels ...<-chan []string) <-chan []string {
+func CombineChannels(channels ...<-chan []BString) <-chan []BString {
 	if channels == nil {
 		return nil
 	}
@@ -16,12 +17,12 @@ func CombineChannels(channels ...<-chan []string) <-chan []string {
 		return channels[0]
 	}
 
-	out := make(chan []string)
+	out := make(chan []BString)
 	var wg sync.WaitGroup
 
 	for _, c := range channels {
 		wg.Add(1)
-		go func(subchan <-chan []string) {
+		go func(subchan <-chan []BString) {
 			for {
 				s, more := <-subchan
 				if !more {
@@ -43,8 +44,9 @@ func CombineChannels(channels ...<-chan []string) <-chan []string {
 
 // ConvertReaderToStringChan converts an io.reader to a string channel
 //  where it's separated by a new-line
-func ConvertReaderToStringChan(reader io.ReadCloser, batchSize int) <-chan []string {
-	out := make(chan []string)
+func ConvertReaderToStringChan(reader io.ReadCloser, batchSize int) <-chan []BString {
+	// TODO: Use new readahead
+	out := make(chan []BString)
 	scanner := bufio.NewScanner(reader)
 	bigBuf := make([]byte, 512*1024)
 	scanner.Buffer(bigBuf, len(bigBuf))
@@ -59,13 +61,36 @@ func ConvertReaderToStringChan(reader io.ReadCloser, batchSize int) <-chan []str
 }
 
 // SyncScannerToBatchChannel reads a scanner into []string chunks and writes to an output channel
-func SyncScannerToBatchChannel(scanner *bufio.Scanner, batchSize int, out chan<- []string) {
-	batch := make([]string, 0, batchSize)
+func SyncScannerToBatchChannel(scanner *bufio.Scanner, batchSize int, out chan<- []BString) {
+	batch := make([]BString, 0, batchSize)
 	for scanner.Scan() {
-		batch = append(batch, scanner.Text())
+		b := scanner.Bytes()
+		cb := make(BString, len(b))
+		copy(cb, b)
+
+		batch = append(batch, cb)
 		if len(batch) >= batchSize {
 			out <- batch
-			batch = make([]string, 0, batchSize)
+			batch = make([]BString, 0, batchSize)
+		}
+	}
+	if len(batch) > 0 {
+		out <- batch
+	}
+}
+
+func SyncReadAheadToBatchChannel(readahead *readahead.ReadAhead, batchSize int, out chan<- []BString) {
+	batch := make([]BString, 0, batchSize)
+	for {
+		b := readahead.ReadLine()
+		if b == nil {
+			break
+		}
+
+		batch = append(batch, b)
+		if len(batch) >= batchSize {
+			out <- batch
+			batch = make([]BString, 0, batchSize)
 		}
 	}
 	if len(batch) > 0 {

--- a/pkg/extractor/ioHelpers_test.go
+++ b/pkg/extractor/ioHelpers_test.go
@@ -7,14 +7,14 @@ import (
 )
 
 func TestCombiningChannels(t *testing.T) {
-	c1 := make(chan []string)
-	c2 := make(chan []string)
+	c1 := make(chan []BString)
+	c2 := make(chan []BString)
 
 	combined := CombineChannels(c1, c2)
-	c1 <- []string{"a"}
-	c2 <- []string{"b"}
-	assert.Equal(t, []string{"a"}, <-combined)
-	assert.Equal(t, []string{"b"}, <-combined)
+	c1 <- []BString{BString("a")}
+	c2 <- []BString{BString("b")}
+	assert.Equal(t, []BString{BString("a")}, <-combined)
+	assert.Equal(t, []BString{BString("b")}, <-combined)
 
 	close(c1)
 	close(c2)

--- a/pkg/readahead/readahead.go
+++ b/pkg/readahead/readahead.go
@@ -40,6 +40,9 @@ func maxi(a, b int) int {
 }
 
 func New(reader io.Reader, maxBufLen int) *ReadAhead {
+	if maxBufLen <= 0 {
+		panic("Buf length must be > 0")
+	}
 	return &ReadAhead{
 		r:         reader,
 		maxBufLen: maxBufLen,

--- a/pkg/readahead/readahead.go
+++ b/pkg/readahead/readahead.go
@@ -1,0 +1,118 @@
+package readahead
+
+import (
+	"bytes"
+	"io"
+)
+
+/*
+Buffered read-ahead similar to Scanner, except it will leave the large-buffers in place
+(rather than shifting them) so that a given slice is good for the duration of its life
+
+This allows a slice reference to be passed around without worrying that the underlying data will change
+which limits the amount the data needs to be copied around
+
+Initial benchmarks shows a 8% savings over Scanner
+*/
+
+type ReadAhead struct {
+	r         io.Reader
+	maxBufLen int
+
+	buf    []byte
+	offset int
+	eof    bool
+}
+
+// dropCR drops a terminal \r from the data.
+func dropCR(data []byte) []byte {
+	if len(data) > 0 && data[len(data)-1] == '\r' {
+		return data[0 : len(data)-1]
+	}
+	return data
+}
+
+func maxi(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+
+func New(reader io.Reader, maxBufLen int) *ReadAhead {
+	return &ReadAhead{
+		r:         reader,
+		maxBufLen: maxBufLen,
+	}
+}
+
+func (s *ReadAhead) ReadLine() []byte {
+	const averageLineLen = 512
+
+	if !s.eof && (s.buf == nil || s.offset > len(s.buf)-averageLineLen) {
+		// Need some more data in the buffer, but want to keep the existing one in-tact
+		// This will lead to a small amount of duplication by copying the remaining data
+		// in the old buf to the new buf
+		oldbuf := s.buf
+		s.buf = make([]byte, maxi(s.maxBufLen, len(oldbuf)-s.offset+s.maxBufLen/2))
+		startRead := 0
+
+		if oldbuf != nil && s.offset < len(oldbuf) {
+			// Copy end of old buf over, and populate the rest of the buffer from reader
+			startRead = len(oldbuf) - s.offset
+			copy(s.buf, oldbuf[s.offset:])
+		} else {
+			// Brand new data!
+			s.offset = 0
+		}
+
+		// Fill buffer
+		for startRead < len(s.buf) {
+			n, err := s.r.Read(s.buf[startRead:])
+			startRead += n
+			if err != nil {
+				s.eof = true
+				break
+			}
+		}
+
+		s.buf = s.buf[:startRead]
+		s.offset = 0
+	}
+
+	for {
+		relIndex := bytes.IndexByte(s.buf[s.offset:], '\n')
+
+		if relIndex >= 0 {
+			start := s.offset
+			s.offset += relIndex + 1
+			return dropCR(s.buf[start : start+relIndex])
+		}
+
+		// No new line, so either:
+		// A) There's not enough room in the buffer
+		// B) We're towards the end of buf, and need more data (Though hopefully we pre-empted above)
+		if relIndex < 0 {
+			// Eof, so the rest of it will count as a line
+			if s.eof && s.offset < len(s.buf) {
+				ret := s.buf[s.offset:]
+				s.offset = len(s.buf)
+				return ret
+			} else if !s.eof {
+				// Not enough in buffer to find next new-line.. need to fill until finding
+				oldbuf := s.buf
+				s.buf = make([]byte, len(s.buf)*2)
+				copy(s.buf, oldbuf)
+
+				n, err := s.r.Read(s.buf[len(oldbuf):])
+				s.buf = s.buf[:len(oldbuf)+n]
+
+				if err != nil {
+					s.eof = true
+				}
+			} else {
+				return nil
+			}
+		}
+	}
+}

--- a/pkg/readahead/readahead_test.go
+++ b/pkg/readahead/readahead_test.go
@@ -1,0 +1,60 @@
+package readahead
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBasicReadingShortBuf(t *testing.T) {
+	r := strings.NewReader("Hello there you\nthis is line 2\n")
+	ra := New(r, 3)
+	assert.Equal(t, []byte("Hello there you"), ra.ReadLine())
+	assert.Equal(t, []byte("this is line 2"), ra.ReadLine())
+	assert.Nil(t, ra.ReadLine())
+}
+
+func TestBasicReadingLongBuf(t *testing.T) {
+	r := strings.NewReader("Hello there you\nthis is line 2\n")
+	ra := New(r, 1024)
+	assert.Equal(t, []byte("Hello there you"), ra.ReadLine())
+	assert.Equal(t, []byte("this is line 2"), ra.ReadLine())
+	assert.Nil(t, ra.ReadLine())
+}
+
+func TestBasicReadingMidBuf(t *testing.T) {
+	r := strings.NewReader("Hello there you\nthis is line 2\n")
+	ra := New(r, 20) // Just enough to read first line, but not both
+	assert.Equal(t, []byte("Hello there you"), ra.ReadLine())
+	assert.Equal(t, []byte("this is line 2"), ra.ReadLine())
+	assert.Nil(t, ra.ReadLine())
+}
+
+func TestBasicReadingNoNewTerm(t *testing.T) {
+	r := strings.NewReader("Hello there you\nthis is line 2")
+	ra := New(r, 3)
+	assert.Equal(t, []byte("Hello there you"), ra.ReadLine())
+	assert.Equal(t, []byte("this is line 2"), ra.ReadLine())
+	assert.Nil(t, ra.ReadLine())
+}
+
+func TestReadEmptyString(t *testing.T) {
+	r := strings.NewReader("")
+	ra := New(r, 3)
+	assert.Nil(t, ra.ReadLine())
+}
+
+func TestReadSingleCharString(t *testing.T) {
+	r := strings.NewReader("A")
+	ra := New(r, 3)
+	assert.Equal(t, []byte("A"), ra.ReadLine())
+}
+
+func TestDropCR(t *testing.T) {
+	r := strings.NewReader("test\r\nthing")
+	ra := New(r, 3)
+	assert.Equal(t, []byte("test"), ra.ReadLine())
+	assert.Equal(t, []byte("thing"), ra.ReadLine())
+	assert.Nil(t, ra.ReadLine())
+}


### PR DESCRIPTION
Before and after benchmarks

```
# Batching extraction
Matched: 1,131,354 / 3,638,594
Groups:  549

real	0m1.157s
user	0m6.020s
sys	0m0.096s

# BString (And no copy)
real	0m1.065s
user	0m5.596s
sys	0m0.172s
```

pprof shows an 8% reduction in time spent scanning and reading files