### PR TITLE
Incremental status

### DIFF
--- a/cmd/analyze.go
+++ b/cmd/analyze.go
@@ -69,6 +69,8 @@ func analyzeFunction(c *cli.Context) error {
 		writer.WriteForLine(line+2, GetReadFileString())
 	})
 
+	writer.Close()
+
 	return nil
 }
 

--- a/cmd/helpers/summary.go
+++ b/cmd/helpers/summary.go
@@ -9,11 +9,14 @@ import (
 	"rare/pkg/humanize"
 )
 
-func FWriteExtractorSummary(extractor *extractor.Extractor) string {
+func FWriteExtractorSummary(extractor *extractor.Extractor, additionalFormat string, args ...interface{}) string {
 	var w bytes.Buffer
 	fmt.Fprintf(&w, "Matched: %s / %s",
 		color.Wrapi(color.BrightGreen, humanize.Hi(extractor.MatchedLines())),
 		color.Wrapi(color.BrightWhite, humanize.Hi(extractor.ReadLines())))
+	if additionalFormat != "" {
+		fmt.Fprintf(&w, additionalFormat, args...)
+	}
 	if extractor.IgnoredLines() > 0 {
 		fmt.Fprintf(&w, " (Ignored: %s)", color.Wrapi(color.Red, humanize.Hi(extractor.IgnoredLines())))
 	}
@@ -21,6 +24,6 @@ func FWriteExtractorSummary(extractor *extractor.Extractor) string {
 }
 
 func WriteExtractorSummary(extractor *extractor.Extractor) {
-	os.Stderr.WriteString(FWriteExtractorSummary(extractor))
+	os.Stderr.WriteString(FWriteExtractorSummary(extractor, ""))
 	os.Stderr.WriteString("\n")
 }

--- a/cmd/helpers/summary.go
+++ b/cmd/helpers/summary.go
@@ -9,21 +9,24 @@ import (
 	"rare/pkg/humanize"
 )
 
-func FWriteExtractorSummary(extractor *extractor.Extractor, additionalFormat string, args ...interface{}) string {
+func FWriteExtractorSummary(extractor *extractor.Extractor, errors uint64, additionalParts ...string) string {
 	var w bytes.Buffer
 	fmt.Fprintf(&w, "Matched: %s / %s",
 		color.Wrapi(color.BrightGreen, humanize.Hi(extractor.MatchedLines())),
 		color.Wrapi(color.BrightWhite, humanize.Hi(extractor.ReadLines())))
-	if additionalFormat != "" {
-		fmt.Fprintf(&w, additionalFormat, args...)
+	for _, p := range additionalParts {
+		w.WriteString(p)
 	}
 	if extractor.IgnoredLines() > 0 {
 		fmt.Fprintf(&w, " (Ignored: %s)", color.Wrapi(color.Red, humanize.Hi(extractor.IgnoredLines())))
+	}
+	if errors > 0 {
+		fmt.Fprintf(&w, " %s", color.Wrapf(color.Red, "(Errors: %v)", humanize.Hi(errors)))
 	}
 	return w.String()
 }
 
 func WriteExtractorSummary(extractor *extractor.Extractor) {
-	os.Stderr.WriteString(FWriteExtractorSummary(extractor, ""))
+	os.Stderr.WriteString(FWriteExtractorSummary(extractor, 0))
 	os.Stderr.WriteString("\n")
 }

--- a/cmd/helpers/summary.go
+++ b/cmd/helpers/summary.go
@@ -15,6 +15,7 @@ func FWriteExtractorSummary(extractor *extractor.Extractor, errors uint64, addit
 		color.Wrapi(color.BrightGreen, humanize.Hi(extractor.MatchedLines())),
 		color.Wrapi(color.BrightWhite, humanize.Hi(extractor.ReadLines())))
 	for _, p := range additionalParts {
+		w.WriteRune(' ')
 		w.WriteString(p)
 	}
 	if extractor.IgnoredLines() > 0 {

--- a/cmd/helpers/updatingAggregator.go
+++ b/cmd/helpers/updatingAggregator.go
@@ -73,7 +73,6 @@ PROCESSING_LOOP:
 	writeOutput()
 	fmt.Println()
 
-	WriteExtractorSummary(ext)
 	if aggregator.ParseErrors() > 0 {
 		fmt.Fprint(os.Stderr, color.Wrapf(color.Red, "Parse Errors: %v\n", humanize.Hi(aggregator.ParseErrors())))
 	}

--- a/cmd/helpers/updatingAggregator.go
+++ b/cmd/helpers/updatingAggregator.go
@@ -5,9 +5,7 @@ import (
 	"os"
 	"os/signal"
 	"rare/pkg/aggregation"
-	"rare/pkg/color"
 	"rare/pkg/extractor"
-	"rare/pkg/humanize"
 	"rare/pkg/multiterm"
 	"sync"
 	"sync/atomic"
@@ -72,8 +70,4 @@ PROCESSING_LOOP:
 
 	writeOutput()
 	fmt.Println()
-
-	if aggregator.ParseErrors() > 0 {
-		fmt.Fprint(os.Stderr, color.Wrapf(color.Red, "Parse Errors: %v\n", humanize.Hi(aggregator.ParseErrors())))
-	}
 }

--- a/cmd/histo.go
+++ b/cmd/histo.go
@@ -39,7 +39,7 @@ func histoFunction(c *cli.Context) error {
 		writeHistoOutput(writer, counter, topItems, reverseSort, sortByKey)
 		writer.InnerWriter().WriteForLine(topItems, FWriteExtractorSummary(ext,
 			counter.ParseErrors(),
-			fmt.Sprintf(" (Groups: %s)", color.Wrapi(color.BrightBlue, counter.GroupCount()))))
+			fmt.Sprintf("(Groups: %s)", color.Wrapi(color.BrightBlue, counter.GroupCount()))))
 		writer.InnerWriter().WriteForLine(topItems+1, GetReadFileString())
 	})
 

--- a/cmd/histo.go
+++ b/cmd/histo.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	. "rare/cmd/helpers"
 	"rare/pkg/aggregation"
 	"rare/pkg/color"
@@ -36,7 +37,9 @@ func histoFunction(c *cli.Context) error {
 
 	RunAggregationLoop(ext, counter, func() {
 		writeHistoOutput(writer, counter, topItems, reverseSort, sortByKey)
-		writer.InnerWriter().WriteForLine(topItems, FWriteExtractorSummary(ext, " (Groups: %s)", color.Wrapi(color.BrightBlue, counter.GroupCount())))
+		writer.InnerWriter().WriteForLine(topItems, FWriteExtractorSummary(ext,
+			counter.ParseErrors(),
+			fmt.Sprintf(" (Groups: %s)", color.Wrapi(color.BrightBlue, counter.GroupCount()))))
 		writer.InnerWriter().WriteForLine(topItems+1, GetReadFileString())
 	})
 

--- a/cmd/histo.go
+++ b/cmd/histo.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
 	. "rare/cmd/helpers"
 	"rare/pkg/aggregation"
 	"rare/pkg/color"
@@ -21,7 +19,6 @@ func writeHistoOutput(writer *multiterm.HistoWriter, counter *aggregation.MatchC
 	for idx, match := range items {
 		writer.WriteForLine(idx, match.Name, match.Item.Count())
 	}
-	writer.InnerWriter().WriteForLine(count, GetReadFileString())
 }
 
 func histoFunction(c *cli.Context) error {
@@ -39,9 +36,11 @@ func histoFunction(c *cli.Context) error {
 
 	RunAggregationLoop(ext, counter, func() {
 		writeHistoOutput(writer, counter, topItems, reverseSort, sortByKey)
+		writer.InnerWriter().WriteForLine(topItems, FWriteExtractorSummary(ext, " (Groups: %s)", color.Wrapi(color.BrightBlue, counter.GroupCount())))
+		writer.InnerWriter().WriteForLine(topItems+1, GetReadFileString())
 	})
 
-	fmt.Fprintf(os.Stderr, "Groups:  %s\n", color.Wrapf(color.BrightWhite, "%d", counter.GroupCount()))
+	writer.InnerWriter().Close()
 
 	return nil
 }

--- a/cmd/tabulate.go
+++ b/cmd/tabulate.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-	"os"
 	. "rare/cmd/helpers"
 	"rare/pkg/aggregation"
 	"rare/pkg/color"
@@ -53,12 +51,9 @@ func tabulateFunction(c *cli.Context) error {
 			writer.WriteRow(line, rowVals...)
 			line++
 		}
-		writer.InnerWriter().WriteForLine(line, GetReadFileString())
+		writer.InnerWriter().WriteForLine(line, FWriteExtractorSummary(ext, " (R: %v; C: %v)", color.Wrapi(color.Yellow, counter.RowCount()), color.Wrapi(color.BrightBlue, counter.ColumnCount())))
+		writer.InnerWriter().WriteForLine(line+1, GetReadFileString())
 	})
-
-	fmt.Fprintf(os.Stderr, "Rows: %s; Cols: %s\n",
-		color.Wrapi(color.Yellow, counter.RowCount()),
-		color.Wrapi(color.BrightBlue, counter.ColumnCount()))
 
 	return nil
 }

--- a/cmd/tabulate.go
+++ b/cmd/tabulate.go
@@ -53,7 +53,7 @@ func tabulateFunction(c *cli.Context) error {
 			line++
 		}
 		writer.InnerWriter().WriteForLine(line, FWriteExtractorSummary(ext, counter.ParseErrors(),
-			fmt.Sprintf(" (R: %v; C: %v)", color.Wrapi(color.Yellow, counter.RowCount()), color.Wrapi(color.BrightBlue, counter.ColumnCount()))))
+			fmt.Sprintf("(R: %v; C: %v)", color.Wrapi(color.Yellow, counter.RowCount()), color.Wrapi(color.BrightBlue, counter.ColumnCount()))))
 		writer.InnerWriter().WriteForLine(line+1, GetReadFileString())
 	})
 

--- a/cmd/tabulate.go
+++ b/cmd/tabulate.go
@@ -57,6 +57,8 @@ func tabulateFunction(c *cli.Context) error {
 		writer.InnerWriter().WriteForLine(line+1, GetReadFileString())
 	})
 
+	writer.InnerWriter().Close()
+
 	return nil
 }
 

--- a/cmd/tabulate.go
+++ b/cmd/tabulate.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	. "rare/cmd/helpers"
 	"rare/pkg/aggregation"
 	"rare/pkg/color"
@@ -51,7 +52,8 @@ func tabulateFunction(c *cli.Context) error {
 			writer.WriteRow(line, rowVals...)
 			line++
 		}
-		writer.InnerWriter().WriteForLine(line, FWriteExtractorSummary(ext, " (R: %v; C: %v)", color.Wrapi(color.Yellow, counter.RowCount()), color.Wrapi(color.BrightBlue, counter.ColumnCount())))
+		writer.InnerWriter().WriteForLine(line, FWriteExtractorSummary(ext, counter.ParseErrors(),
+			fmt.Sprintf(" (R: %v; C: %v)", color.Wrapi(color.Yellow, counter.RowCount()), color.Wrapi(color.BrightBlue, counter.ColumnCount()))))
 		writer.InnerWriter().WriteForLine(line+1, GetReadFileString())
 	})
 

--- a/pkg/multiterm/multiterm.go
+++ b/pkg/multiterm/multiterm.go
@@ -7,18 +7,22 @@ import (
 
 type MultilineTerm interface {
 	WriteForLine(line int, format string, args ...interface{})
+	Close()
 }
 
 type TermWriter struct {
 	cursor       int
 	cursorHidden bool
-	ClearLine    bool
-	HideCursor   bool
+	maxLine      int
+
+	ClearLine  bool
+	HideCursor bool
 }
 
 func New() *TermWriter {
 	return &TermWriter{
 		cursor:     0,
+		maxLine:    0,
 		ClearLine:  true,
 		HideCursor: true,
 	}
@@ -34,7 +38,14 @@ func (s *TermWriter) WriteForLine(line int, format string, args ...interface{}) 
 	s.writeAtCursor(format, args...)
 }
 
+func (s *TermWriter) Close() {
+	s.goTo(s.maxLine)
+}
+
 func (s *TermWriter) goTo(line int) {
+	if line > s.maxLine {
+		s.maxLine = line
+	}
 	for i := s.cursor; i < line; i++ {
 		fmt.Print("\n")
 		s.cursor++

--- a/pkg/multiterm/multiterm_test.go
+++ b/pkg/multiterm/multiterm_test.go
@@ -20,6 +20,8 @@ func (s *VirtualTerm) WriteForLine(line int, format string, args ...interface{})
 	s.lines[line] = fmt.Sprintf(format, args...)
 }
 
+func (s *VirtualTerm) Close() {}
+
 func (s *VirtualTerm) Get(line int) string {
 	return s.lines[line]
 }


### PR DESCRIPTION
Always output number of read lines, ignores, and errors in incremental ways (Rather than waiting until completion).

Required small refactoring of `multiterm`