### PR TITLE
Async path walk

### DIFF
--- a/cmd/helpers/extractorBuilder.go
+++ b/cmd/helpers/extractorBuilder.go
@@ -54,7 +54,7 @@ func BuildExtractorFromArguments(c *cli.Context) *extractor.Extractor {
 		}
 
 		tailChannels := make([]<-chan extractor.InputBatch, 0)
-		for _, filename := range globExpand(fileglobs, recursive) {
+		for filename := range globExpand(fileglobs, recursive) {
 			tail, err := tail.TailFile(filename, tail.Config{Follow: true, ReOpen: followReopen, Poll: followPoll})
 
 			if err != nil {

--- a/cmd/helpers/readChannels.go
+++ b/cmd/helpers/readChannels.go
@@ -74,18 +74,6 @@ func openFileToReader(filename string, gunzip bool) (io.ReadCloser, error) {
 	return file, nil
 }
 
-// Aggregate one channel into another, with a buffer
-func bufferChan(in <-chan string, size int) <-chan string {
-	out := make(chan string, size)
-	go func() {
-		for item := range in {
-			out <- item
-		}
-		close(out)
-	}()
-	return out
-}
-
 // openFilesToChan takes an iterated channel of filenames, options, and loads them all with
 //  a max concurrency.  Returns a channel that will populate with input batches
 func openFilesToChan(filenames <-chan string, gunzip bool, concurrency int, batchSize int) <-chan extractor.InputBatch {

--- a/cmd/helpers/readProgress.go
+++ b/cmd/helpers/readProgress.go
@@ -16,6 +16,11 @@ func IncSourceCount(delta int) {
 	sourceCount += delta
 }
 
+// SetSourceCount sets the number of source files
+func SetSourceCount(count int) {
+	sourceCount = count
+}
+
 // StartFileReading registers a given source as being read in the global read-pool
 func StartFileReading(source string) {
 	activeReadMutex.Lock()

--- a/cmd/helpers/util.go
+++ b/cmd/helpers/util.go
@@ -5,6 +5,18 @@ import (
 	"path/filepath"
 )
 
+// Aggregate one channel into another, with a buffer
+func bufferChan(in <-chan string, size int) <-chan string {
+	out := make(chan string, size)
+	go func() {
+		for item := range in {
+			out <- item
+		}
+		close(out)
+	}()
+	return out
+}
+
 func isDir(path string) bool {
 	if fi, err := os.Stat(path); err == nil && fi.IsDir() {
 		return true

--- a/cmd/helpers/util.go
+++ b/cmd/helpers/util.go
@@ -13,29 +13,34 @@ func isDir(path string) bool {
 }
 
 // globExpand expands a directory-glob, and optionally recurses on it
-func globExpand(paths []string, recursive bool) []string {
-	out := make([]string, 0)
-	for _, p := range paths {
-		if recursive && isDir(p) {
-			filepath.Walk(p, func(walkPath string, info os.FileInfo, err error) error {
-				if err != nil {
-					return err
-				}
-				if !info.IsDir() {
-					out = append(out, walkPath)
-				}
-				return nil
-			})
-		} else {
-			expanded, err := filepath.Glob(p)
-			if err != nil {
-				ErrLog.Printf("Path error: %v\n", err)
+func globExpand(paths []string, recursive bool) <-chan string {
+	c := make(chan string, 10)
+	go func() {
+		for _, p := range paths {
+			if recursive && isDir(p) {
+				filepath.Walk(p, func(walkPath string, info os.FileInfo, err error) error {
+					if err != nil {
+						return err
+					}
+					if !info.IsDir() {
+						c <- walkPath
+					}
+					return nil
+				})
 			} else {
-				out = append(out, expanded...)
+				expanded, err := filepath.Glob(p)
+				if err != nil {
+					ErrLog.Printf("Path error: %v\n", err)
+				} else {
+					for _, item := range expanded {
+						c <- item
+					}
+				}
 			}
 		}
-	}
-	return out
+		close(c)
+	}()
+	return c
 }
 
 func min(a, b int) int {

--- a/cmd/helpers/util_test.go
+++ b/cmd/helpers/util_test.go
@@ -1,0 +1,26 @@
+package helpers
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBufferingChan(t *testing.T) {
+	var wg sync.WaitGroup
+
+	c := make(chan string)
+	wg.Add(1)
+	go func() {
+		for i := 0; i < 100; i++ {
+			c <- "hi"
+		}
+		close(c)
+		wg.Done()
+	}()
+
+	bc := bufferChan(c, 100)
+	wg.Wait()
+	assert.Equal(t, 100, len(bc))
+}

--- a/cmd/helpers/util_test.go
+++ b/cmd/helpers/util_test.go
@@ -3,6 +3,7 @@ package helpers
 import (
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -22,5 +23,8 @@ func TestBufferingChan(t *testing.T) {
 
 	bc := bufferChan(c, 100)
 	wg.Wait()
-	assert.Equal(t, 100, len(bc))
+
+	assert.Eventually(t, func() bool {
+		return len(bc) == 100
+	}, 1*time.Second, 10*time.Millisecond)
 }


### PR DESCRIPTION
This MR will allow the file-reader to start reading before all file paths have been resolved via a `Walk`