### PR TITLE
Stop panic when coloring groups with inner groups.

### DIFF
--- a/pkg/color/coloring.go
+++ b/pkg/color/coloring.go
@@ -89,17 +89,7 @@ func WrapIndices(s string, groups []int) string {
 	for i := 0; i < len(groups); i += 2 {
 		start := groups[i]
 		end := groups[i+1]
-
-		// check to see if the next group is an inner group
-		if i+2 < len(groups) {
-			nextStart := groups[i+2]
-			if end > nextStart {
-				// stop coloring before start of next group
-				end = nextStart
-			}
-		}
-
-		if start >= 0 && end >= 0 {
+		if start >= 0 && end >= 0 && end > start && start >= lastIndex {
 			color := groupColors[(i/2)%len(groupColors)]
 
 			sb.WriteString(s[lastIndex:start])

--- a/pkg/color/coloring.go
+++ b/pkg/color/coloring.go
@@ -89,6 +89,16 @@ func WrapIndices(s string, groups []int) string {
 	for i := 0; i < len(groups); i += 2 {
 		start := groups[i]
 		end := groups[i+1]
+
+		// check to see if the next group is an inner group
+		if i+2 < len(groups) {
+			nextStart := groups[i+2]
+			if end > nextStart {
+				// stop coloring before start of next group
+				end = nextStart
+			}
+		}
+
 		if start >= 0 && end >= 0 {
 			color := groupColors[(i/2)%len(groupColors)]
 

--- a/pkg/color/coloring_test.go
+++ b/pkg/color/coloring_test.go
@@ -24,6 +24,18 @@ func BenchmarkColorReplacer(b *testing.B) {
 	fmt.Println(out)
 }
 
+func BenchmarkColorReplacerOverlapping(b *testing.B) {
+	s := "This is a test"
+	groups := []int{4, 7, 5, 6, 8, 9}
+
+	var out string
+	for n := 0; n < b.N; n++ {
+		out = WrapIndices(s, groups)
+	}
+
+	fmt.Println(out)
+}
+
 func TestWrap(t *testing.T) {
 	s := Wrap(Red, "hello")
 	assert.Contains(t, s, Red)
@@ -66,10 +78,6 @@ func TestWrapIndices(t *testing.T) {
 }
 
 func TestWrapIndicesInnerGroups(t *testing.T) {
-	s := WrapIndices("abcdefg", []int{0, 3, 1, 2, 5, 6})
+	s := WrapIndices("abcdefg", []int{0, 2, 1, 2, 5, 6})
 	assert.Contains(t, s, "cde")
-	assert.Contains(t, s, Red)
-	assert.Contains(t, s, Green)
-	assert.Contains(t, s, Yellow)
-	assert.Contains(t, s, Reset)
 }

--- a/pkg/color/coloring_test.go
+++ b/pkg/color/coloring_test.go
@@ -64,3 +64,12 @@ func TestWrapIndices(t *testing.T) {
 	assert.Contains(t, s, Green)
 	assert.Contains(t, s, Reset)
 }
+
+func TestWrapIndicesInnerGroups(t *testing.T) {
+	s := WrapIndices("abcdefg", []int{0, 3, 1, 2, 5, 6})
+	assert.Contains(t, s, "cde")
+	assert.Contains(t, s, Red)
+	assert.Contains(t, s, Green)
+	assert.Contains(t, s, Yellow)
+	assert.Contains(t, s, Reset)
+}


### PR DESCRIPTION
This is a trivial change that does not resume coloring the outer
group at the end of the inner group.