### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ brew install rare
 
 Clone the repo, and:
 
-Requires GO 1.11 or higher (Uses go modules)
+Requires GO 1.16 or higher
 
 ```sh
 go mod download


### PR DESCRIPTION
Require Go 1.16 for rare, now makes use of go:embed. Fixes https://github.com/zix99/rare/issues/46