### PR TITLE
Allow outputing matched data as json

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -9,6 +9,14 @@ Please feel free to contribute your own examples on github
 $ rare filter --match "(\d+)" input.txt
 ```
 
+### Extract matched value as JSON
+```sh
+$ rare f --match "(?P<val>\d+)" -e "{.}" simple.log
+{"val": 1}
+{"val": 2}
+{"val": 1}
+```
+
 ### Histogram of Numbers in Text
 ```sh
 $ rare histo --match "(\d+)" -e "{1}" -x input.txt

--- a/docs/expressions.md
+++ b/docs/expressions.md
@@ -27,6 +27,9 @@ The following are special Keys:
 
  * `{src}`  The source name (eg filename). `stdin` when read from stdin
  * `{line}` The line numbers of the current match
+ * `{.}`    Returns all matched values with match names as JSON
+ * `{#}`    Returns all matched numbered values as JSON
+ * `{.#}`   Returned numbered and named matches as JSON
 
 ## Examples
 

--- a/pkg/expressions/stdlib/funcs.go
+++ b/pkg/expressions/stdlib/funcs.go
@@ -53,9 +53,9 @@ var StandardFunctions = map[string]KeyBuilderFunction{
 	"substr": KeyBuilderFunction(kfSubstr),
 	"select": KeyBuilderFunction(kfSelect),
 
-	// Separation
-	"tab": kfSeparate('\t'),
-	"$":   kfSeparate(ArraySeparator),
+	// Separation (Join)
+	"tab": kfJoin('\t'),
+	"$":   kfJoin(ArraySeparator),
 
 	// Pathing
 	"basename": kfPathBase,
@@ -67,7 +67,7 @@ var StandardFunctions = map[string]KeyBuilderFunction{
 	"hf": KeyBuilderFunction(kfHumanizeFloat),
 
 	// Json
-	"json": KeyBuilderFunction(kfJson),
+	"json": KeyBuilderFunction(kfJsonQuery),
 
 	// CSV
 	"csv": KeyBuilderFunction(kfCsv),

--- a/pkg/expressions/stdlib/funcsJson.go
+++ b/pkg/expressions/stdlib/funcsJson.go
@@ -6,14 +6,16 @@ import (
 	. "rare/pkg/expressions" //lint:ignore ST1001 Legacy
 )
 
-func kfJson(args []KeyBuilderStage) KeyBuilderStage {
+func kfJsonQuery(args []KeyBuilderStage) KeyBuilderStage {
 	if len(args) == 1 {
+		// Assumes "{0}" is the json blog to extract, so arg[0] is the key
 		return KeyBuilderStage(func(context KeyBuilderContext) string {
 			json := context.GetMatch(0)
 			expression := args[0](context)
 			return gjson.Get(json, expression).String()
 		})
 	} else if len(args) == 2 {
+		// Json is arg[0], key is arg[1]
 		return KeyBuilderStage(func(context KeyBuilderContext) string {
 			json := args[0](context)
 			expression := args[1](context)

--- a/pkg/expressions/stdlib/funcsStrings.go
+++ b/pkg/expressions/stdlib/funcsStrings.go
@@ -168,7 +168,7 @@ func kfBytesize(args []KeyBuilderStage) KeyBuilderStage {
 	})
 }
 
-func kfSeparate(delim rune) KeyBuilderFunction {
+func kfJoin(delim rune) KeyBuilderFunction {
 	return func(args []KeyBuilderStage) KeyBuilderStage {
 		if len(args) == 0 {
 			return stageLiteral("")

--- a/pkg/minijson/minijson.go
+++ b/pkg/minijson/minijson.go
@@ -1,0 +1,115 @@
+package minijson
+
+import (
+	"strconv"
+	"strings"
+)
+
+/*
+A JSON writer that is explicit and doesn't marshal/unmarshal
+*/
+
+type JsonObjectBuilder struct {
+	sb       strings.Builder
+	keyCount int
+}
+
+func (s *JsonObjectBuilder) OpenEx(hint int) {
+	if hint > 0 {
+		s.sb.Grow(hint)
+	}
+	s.sb.WriteRune('{')
+}
+
+func (s *JsonObjectBuilder) Open() {
+	s.OpenEx(0)
+}
+
+func (s *JsonObjectBuilder) Close() {
+	s.sb.WriteRune('}')
+}
+
+func (s *JsonObjectBuilder) String() string {
+	return s.sb.String()
+}
+
+func (s *JsonObjectBuilder) KeyCount() int {
+	return s.keyCount
+}
+
+func (s *JsonObjectBuilder) WriteInferred(key, val string) {
+	if isNumeric(val) {
+		s.WriteLiteral(key, val)
+	} else if strings.EqualFold(val, "true") {
+		s.WriteLiteral(key, "true")
+	} else if strings.EqualFold(val, "false") {
+		s.WriteLiteral(key, "false")
+	} else {
+		s.WriteString(key, val)
+	}
+}
+
+// Write a {"Key": literal} (Note, no quotes in literal)
+func (s *JsonObjectBuilder) WriteLiteral(key, literal string) {
+	s.writeKey(key)
+	s.sb.WriteString(literal)
+}
+
+func (s *JsonObjectBuilder) WriteString(key, val string) {
+	s.writeKey(key)
+	s.sb.WriteRune('"')
+	s.sb.WriteString(escape(val))
+	s.sb.WriteRune('"')
+}
+
+func (s *JsonObjectBuilder) WriteInt(key string, val int) {
+	s.writeKey(key)
+	s.sb.WriteString(strconv.Itoa(val))
+}
+
+func (s *JsonObjectBuilder) writeKey(key string) {
+	if s.keyCount > 0 {
+		s.sb.WriteString(", ")
+	}
+	s.sb.WriteRune('"')
+	s.sb.WriteString(key)
+	s.sb.WriteString("\": ")
+	s.keyCount++
+}
+
+func escape(s string) string {
+	var sb strings.Builder
+	sb.Grow(len(s) + 5)
+
+	for _, v := range s {
+		switch v {
+		case '\b':
+			sb.WriteString("\\b")
+		case '\f':
+			sb.WriteString("\\f")
+		case '\n':
+			sb.WriteString("\\n")
+		case '\r':
+			sb.WriteString("\\r")
+		case '\t':
+			sb.WriteString("\\t")
+		case '"':
+			sb.WriteString(`\"`)
+		case '\\':
+			sb.WriteString(`\\`)
+		default:
+			sb.WriteRune(v)
+		}
+	}
+
+	return sb.String()
+}
+
+func isNumeric(s string) bool {
+	for _, r := range s {
+		if (r < '0' || r > '9') && r != '.' {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/minijson/minijson_test.go
+++ b/pkg/minijson/minijson_test.go
@@ -1,0 +1,97 @@
+package minijson
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestEmptyObject(t *testing.T) {
+	var jb JsonObjectBuilder
+	assert.Empty(t, jb.String())
+
+	jb.Open()
+	jb.Close()
+	assert.Equal(t, "{}", jb.String())
+}
+
+func TestSingleObject(t *testing.T) {
+	var jb JsonObjectBuilder
+	jb.OpenEx(5)
+	jb.WriteString("key", "val")
+	jb.Close()
+	assert.Equal(t, `{"key": "val"}`, jb.String())
+}
+
+func TestMultiObject(t *testing.T) {
+	var jb JsonObjectBuilder
+	jb.OpenEx(5)
+	jb.WriteString("key", "val")
+	jb.WriteString("key2", "val2")
+	jb.Close()
+	assert.Equal(t, `{"key": "val", "key2": "val2"}`, jb.String())
+}
+
+func TestWriteInt(t *testing.T) {
+	var jb JsonObjectBuilder
+	jb.Open()
+	jb.WriteInt("k", 123)
+	jb.Close()
+	assert.Equal(t, `{"k": 123}`, jb.String())
+}
+
+func TestWriteInferred(t *testing.T) {
+	var jb JsonObjectBuilder
+	jb.Open()
+	jb.WriteInferred("s", "\nstring")
+	jb.WriteInferred("n", "123")
+	jb.WriteInferred("f", "123.2")
+	jb.WriteInferred("t", "True")
+	jb.WriteInferred("fa", "FALSE")
+	jb.Close()
+
+	assert.Equal(t, `{"s": "\nstring", "n": 123, "f": 123.2, "t": true, "fa": false}`, jb.String())
+}
+
+func TestIsNumeric(t *testing.T) {
+	assert.True(t, isNumeric("1"))
+	assert.True(t, isNumeric("123"))
+	assert.True(t, isNumeric("1.2"))
+	assert.True(t, isNumeric("1000"))
+	assert.False(t, isNumeric("0123a"))
+	assert.False(t, isNumeric("qq"))
+}
+
+func TestEscape(t *testing.T) {
+	assert.Equal(t, "this is normal", escape("this is normal"))
+	assert.Equal(t, `\r\n new\t\t`, escape("\r\n new\t\t"))
+}
+
+var mapData = map[string]string{
+	"s":  "string",
+	"n":  "123",
+	"f":  "123.2",
+	"t":  "True",
+	"fa": "FALSE",
+}
+
+func BenchmarkJsonMarshal(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		json.Marshal(mapData)
+	}
+}
+
+// BenchmarkJsonBuilder-4   	  807200	      1344 ns/op	     256 B/op	       1 allocs/op
+func BenchmarkJsonBuilder(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		MarshalStringMapInferred(mapData)
+	}
+}
+
+// BenchmarkEscape-4   	 1938726	       567.6 ns/op	      32 B/op	       1 allocs/op
+func BenchmarkEscape(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		escape("\nthis is a test!")
+	}
+}

--- a/pkg/minijson/util.go
+++ b/pkg/minijson/util.go
@@ -1,0 +1,11 @@
+package minijson
+
+func MarshalStringMapInferred(s map[string]string) string {
+	var jb JsonObjectBuilder
+	jb.OpenEx(len(s) * 50)
+	for k, v := range s {
+		jb.WriteString(k, v)
+	}
+	jb.Close()
+	return jb.String()
+}

--- a/pkg/minijson/util_test.go
+++ b/pkg/minijson/util_test.go
@@ -1,0 +1,16 @@
+package minijson
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMapToJSON(t *testing.T) {
+	m := map[string]string{
+		"a": "b",
+		"c": "123",
+	}
+	val := MarshalStringMapInferred(m)
+	assert.Equal(t, `{"a": "b", "c": "123"}`, val)
+}

--- a/pkg/minijson/util_test.go
+++ b/pkg/minijson/util_test.go
@@ -1,6 +1,7 @@
 package minijson
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -12,5 +13,10 @@ func TestMapToJSON(t *testing.T) {
 		"c": "123",
 	}
 	val := MarshalStringMapInferred(m)
-	assert.Equal(t, `{"a": "b", "c": "123"}`, val)
+
+	// Order is non-deterministic, so check for contents
+	assert.Contains(t, val, `"a": "b"`)
+	assert.Contains(t, val, `"c": "123"`)
+	assert.True(t, strings.HasPrefix(val, "{"))
+	assert.True(t, strings.HasSuffix(val, "}"))
 }


### PR DESCRIPTION
Allows outputting matched data names or indices as JSON.  In addition to building manual expressions, this will allow passing output data to other applications (eg. `jq`) in a complete way.

Example syntax:
```sh
rare filter --match "(?P<val>\d+)" --extract "{.} {#} {.#}" input.txt
```