### PR TITLE
Introduce timed flush

### DIFF
--- a/pkg/extractor/batchers/batcher.go
+++ b/pkg/extractor/batchers/batcher.go
@@ -16,6 +16,9 @@ import (
 // ReadAheadBufferSize is the default size of the read-ahead buffer
 const ReadAheadBufferSize = 128 * 1024
 
+// AutoFlushTimeout sets time before an auto-flushing reader will write a batch
+const AutoFlushTimeout = 250 * time.Millisecond
+
 type Batcher struct {
 	c chan extractor.InputBatch
 

--- a/pkg/extractor/batchers/batcher_test.go
+++ b/pkg/extractor/batchers/batcher_test.go
@@ -3,6 +3,7 @@ package batchers
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -32,6 +33,24 @@ line2
 line3`
 
 	s.syncReaderToBatcher("string", strings.NewReader(testData), 2)
+
+	b1 := <-s.BatchChan()
+	b2 := <-s.BatchChan()
+
+	assert.Len(t, b1.Batch, 2)
+	assert.Len(t, b2.Batch, 1)
+	assert.Equal(t, s.errorCount, 0)
+	assert.Equal(t, s.ReadBytes(), uint64(17))
+}
+
+func TestBatcherWithAutoFlush(t *testing.T) {
+	s := newBatcher(10)
+
+	testData := `line1
+line2
+line3`
+
+	s.syncReaderToBatcherWithTimeFlush("string", strings.NewReader(testData), 2, 1*time.Second)
 
 	b1 := <-s.BatchChan()
 	b2 := <-s.BatchChan()

--- a/pkg/extractor/batchers/readerBatcher.go
+++ b/pkg/extractor/batchers/readerBatcher.go
@@ -2,7 +2,6 @@ package batchers
 
 import (
 	"io"
-	"time"
 )
 
 func OpenReaderToChan(sourceName string, reader io.ReadCloser, batchSize int) *Batcher {
@@ -12,7 +11,7 @@ func OpenReaderToChan(sourceName string, reader io.ReadCloser, batchSize int) *B
 		defer reader.Close()
 		defer out.close()
 		out.startFileReading(sourceName)
-		out.syncReaderToBatcherWithTimeFlush(sourceName, reader, batchSize, 250*time.Millisecond)
+		out.syncReaderToBatcherWithTimeFlush(sourceName, reader, batchSize, AutoFlushTimeout)
 	}()
 
 	return out

--- a/pkg/extractor/batchers/readerBatcher.go
+++ b/pkg/extractor/batchers/readerBatcher.go
@@ -2,6 +2,7 @@ package batchers
 
 import (
 	"io"
+	"time"
 )
 
 func OpenReaderToChan(sourceName string, reader io.ReadCloser, batchSize int) *Batcher {
@@ -11,7 +12,7 @@ func OpenReaderToChan(sourceName string, reader io.ReadCloser, batchSize int) *B
 		defer reader.Close()
 		defer out.close()
 		out.startFileReading(sourceName)
-		out.syncReaderToBatcher(sourceName, reader, batchSize)
+		out.syncReaderToBatcherWithTimeFlush(sourceName, reader, batchSize, 250*time.Millisecond)
 	}()
 
 	return out

--- a/pkg/extractor/batchers/tailBatcher.go
+++ b/pkg/extractor/batchers/tailBatcher.go
@@ -4,7 +4,6 @@ import (
 	"rare/pkg/followreader"
 	"rare/pkg/logger"
 	"sync"
-	"time"
 )
 
 // TailFilesToChan tails a set of files to an input batcher that can be consumed by extractor
@@ -30,7 +29,7 @@ func TailFilesToChan(filenames <-chan string, batchSize int, reopen, poll bool) 
 					return
 				}
 
-				out.syncReaderToBatcherWithTimeFlush(filename, r, batchSize, 250*time.Millisecond)
+				out.syncReaderToBatcherWithTimeFlush(filename, r, batchSize, AutoFlushTimeout)
 			}(filename)
 		}
 

--- a/pkg/extractor/batchers/tailBatcher.go
+++ b/pkg/extractor/batchers/tailBatcher.go
@@ -4,6 +4,7 @@ import (
 	"rare/pkg/followreader"
 	"rare/pkg/logger"
 	"sync"
+	"time"
 )
 
 // TailFilesToChan tails a set of files to an input batcher that can be consumed by extractor
@@ -29,7 +30,7 @@ func TailFilesToChan(filenames <-chan string, batchSize int, reopen, poll bool) 
 					return
 				}
 
-				out.syncReaderToBatcher(filename, r, batchSize)
+				out.syncReaderToBatcherWithTimeFlush(filename, r, batchSize, 250*time.Millisecond)
 			}(filename)
 		}
 


### PR DESCRIPTION
Timed flush allows streams (stdin, following) to flush a batch before an entire batch has read if a duration times out. Defaults to 250ms