### PR TITLE
chore: update GoReleaser and goreleaser-action and fix deprecation warning

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,9 +32,9 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v1
+        uses: goreleaser/goreleaser-action@v6.1.0
         with:
-          version: v1.1.0
+          version: v2.5.0
           args: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUBTOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,3 +1,4 @@
+version: 2
 before:
   hooks:
     - sh -c "go run . _gendoc --man | gzip > rare.1.gz"
@@ -44,12 +45,12 @@ builds:
 
 archives:
 - allow_different_binary_count: true
-  replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    386: i386
-    amd64: x86_64
+  name_template: >-
+    {{- .ProjectName }}_
+    {{- .Version }}_
+    {{- title .Os }}_
+    {{- if eq .Arch "amd64" }}x86_64
+    {{- else }}{{ .Arch }}{{ end -}}
   format_overrides:
     - goos: windows
       format: zip
@@ -61,7 +62,7 @@ archives:
 checksum:
   name_template: 'checksums.txt'
 snapshot:
-  name_template: "{{ .Tag }}-next"
+  version_template: "{{ .Tag }}-next"
 changelog:
   sort: asc
   filters:
@@ -87,7 +88,7 @@ nfpms:
       dst: /usr/share/man/man1/rare.1.gz
 
 brews:
-- tap:
+- repository:
     owner: zix99
     name: homebrew-rare
   commit_author:


### PR DESCRIPTION
Close #113

## Test

```console
$ goreleaser check
  • checking                                 path=.goreleaser.yml
  • 1 configuration file(s) validated
  • thanks for using goreleaser!
```

I've confirmed the release works well on my fork.

https://github.com/suzuki-shunsuke/rare/releases/tag/0.4.1-2

<img width="348" alt="image" src="https://github.com/user-attachments/assets/57a9c5f4-6c08-45f0-8bd5-3127df85bc52" />

Warning was resolved.

https://github.com/suzuki-shunsuke/rare/actions/runs/12408310896/job/34639749064

This change keeps the naming format.

Before:

https://github.com/zix99/rare/releases/tag/0.3.4

```
checksums.txt
rare_0.3.4_Darwin_arm64.tar.gz
rare_0.3.4_Darwin_x86_64.tar.gz
rare_0.3.4_Linux_arm64.tar.gz
rare_0.3.4_Linux_x86_64.tar.gz
rare_0.3.4_Windows_arm64.zip
rare_0.3.4_Windows_x86_64.zip
rare_amd64.apk
rare_amd64.deb
rare_amd64.rpm
rare_arm64.apk
rare_arm64.deb
rare_arm64.rpm
```

After:

https://github.com/suzuki-shunsuke/rare/releases/tag/0.4.1-2

```
checksums.txt
rare_0.4.1-2_Darwin_arm64.tar.gz
rare_0.4.1-2_Darwin_x86_64.tar.gz
rare_0.4.1-2_Linux_arm64.tar.gz
rare_0.4.1-2_Linux_x86_64.tar.gz
rare_0.4.1-2_Windows_arm64.zip
rare_0.4.1-2_Windows_x86_64.zip
rare_amd64.apk
rare_amd64.deb
rare_amd64.rpm
rare_arm64.apk
rare_arm64.deb
rare_arm64.rpm
```