### PR TITLE
Fix typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Besides your standard OS versions, there is an additional `pcre` build which is 
 
 PCRE2 also comes with pitfalls, two of the most important are:
 1. That *rare* is now dynamically linked, meaning that you need to have libc and libpcre installed
-2. That pcre is an exponential-time algorithm (re2 is linear).  While it can be significantly faster than go's `re2`, it can also be catastropically slower in some situations. There is a good post [here](https://swtch.com/~rsc/regexp/regexp1.html) that talks about regexp timings.
+2. That pcre is an exponential-time algorithm (re2 is linear).  While it can be significantly faster than go's `re2`, it can also be catastrophically slower in some situations. There is a good post [here](https://swtch.com/~rsc/regexp/regexp1.html) that talks about regexp timings.
 
 I will leave it up to the user as to which they find suitable to use for their situation.  Generally, if you know what *rare* is getting as an input, the pcre version is perfectly safe and can be much faster.
 
@@ -140,7 +140,7 @@ $ rare histo input.txt
 Matched: 6 / 6 (Groups: 4)
 ```
 
-### Extact status and size from nginx logs
+### Extract status and size from nginx logs
 ```sh
 $ rare filter -n 4 -m "(\d{3}) (\d+)" -e "{1} {2}" access.log
 404 169

--- a/cmd/spark.go
+++ b/cmd/spark.go
@@ -97,7 +97,7 @@ func sparkCommand() *cli.Command {
 			},
 			&cli.BoolFlag{
 				Name:  "notruncate",
-				Usage: "Disable truncating data that doesnt fit in the sparkline",
+				Usage: "Disable truncating data that doesn't fit in the sparkline",
 				Value: false,
 			},
 			&cli.StringFlag{

--- a/docs/cli-help.md
+++ b/docs/cli-help.md
@@ -245,7 +245,7 @@ Create rows of sparkline graphs
 
 **--noout**: Don't output any aggregation to stdout
 
-**--notruncate**: Disable truncating data that doesnt fit in the sparkline
+**--notruncate**: Disable truncating data that doesn't fit in the sparkline
 
 **--num, --rows, -n**="": Number of elements (rows) to display (default: 20)
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,7 +38,7 @@ Take a look at [examples](usage/examples.md) to see more of what *rare* does.
 
     PCRE2 also comes with pitfalls, two of the most important are:
     1. That *rare* is now dynamically linked, meaning that you need to have libc and libpcre installed
-    2. That pcre is an exponential-time algorithm (re2 is linear).  While it can be significantly faster than go's `re2`, it can also be catastropically slower in some situations. There is a good post [here](https://swtch.com/~rsc/regexp/regexp1.html) that talks about regexp timings.
+    2. That pcre is an exponential-time algorithm (re2 is linear).  While it can be significantly faster than go's `re2`, it can also be catastrophically slower in some situations. There is a good post [here](https://swtch.com/~rsc/regexp/regexp1.html) that talks about regexp timings.
 
     I will leave it up to the user as to which they find suitable to use for their situation.  Generally, if you know what *rare* is getting as an input, the pcre version is perfectly safe and can be much faster.
 

--- a/docs/usage/aggregators.md
+++ b/docs/usage/aggregators.md
@@ -44,7 +44,7 @@ rare help histogram
 
 ### Summary
 
-The histogram format outputs an aggregation by counting the occurences
+The histogram format outputs an aggregation by counting the occurrences
 of an extracted match.  That is to say, on every line a regex will be
 matched (or not), and the matched groups can be used to extract and build
 a key, that will act as the bucketing name.

--- a/docs/usage/expressions.md
+++ b/docs/usage/expressions.md
@@ -90,7 +90,7 @@ Arguments surrounded by `[]` are optional.
 
 Syntax: `{coalesce ...}`
 
-Evaluates arguments in-order, chosing the first non-empty result.
+Evaluates arguments in-order, choosing the first non-empty result.
 
 #### Select Field
 
@@ -503,11 +503,11 @@ Parse a given time-string into a unix second time (default format: `cache`)
 
 ##### Format Auto-Detection
 
-If the format argument is ommitted or set to "auto", it will attempt to resolve the format of the time.
+If the format argument is omitted or set to "auto", it will attempt to resolve the format of the time.
 
 If the format is unable to be resolved, it must be specified manually with a format below, or a custom format.
 
-If ommitted or "cache": The first seen date will determine the format for all dates going forward (faster)
+If omitted or "cache": The first seen date will determine the format for all dates going forward (faster)
 
 If "auto": The date format will be auto-detected with each parse. This can be used if the date could be in different formats (slower)
 
@@ -566,7 +566,7 @@ Syntax: `{duration dur}`
 
 Use a duration expressed in s,m,h and convert it to seconds eg `{duration 24h}`
 
-From there, you can do arithmatic on time, for instance: `{sumi {time now} {duration 1h}}`
+From there, you can do arithmetic on time, for instance: `{sumi {time now} {duration 1h}}`
 
 ##### Format Duration
 

--- a/docs/usage/input.md
+++ b/docs/usage/input.md
@@ -59,11 +59,11 @@ you can specify `-t` or `--tail` to start following at the end.
 
 There are two ways to read from a pipe: implicit and explicit.
 
-Implicitely, if *rare* detects its stdin is a pipe, it will read it simply by not providing any arguments
+Implicitly, if *rare* detects its stdin is a pipe, it will read it simply by not providing any arguments
 
 `cat file.log | rare <aggregator>` or `rare <aggregator> < file.log`
 
-Explicitely, you can pass a single read argument of `-` (dash) to mandate reading from stdin
+Explicitly, you can pass a single read argument of `-` (dash) to mandate reading from stdin
 
 `cat file.log | rare <aggregator> -`
 
@@ -93,7 +93,7 @@ at the cost of being less real-time if input generation is slow.
 
 To counteract this, in the *follow* or *stdin* cases, there's also a flush timeout of
 250ms. This means if a new line has been received, and the duration has passed,
-that the batch will be processed irregardless of its current size.
+that the batch will be processed regardless of its current size.
 
 You can tweak this value with `--batch`
 

--- a/docs/usage/overview.md
+++ b/docs/usage/overview.md
@@ -39,7 +39,7 @@ Read more at:
 
 Expressions `-e` take the match groups, and other pieces of information, and build
 a string-based key.  The match groups can be operated on by helpers to build
-the string-key (eg arithmatic, json parsing, simple logic).
+the string-key (eg arithmetic, json parsing, simple logic).
 
 The result of this key will act as the key for the aggregation stage.
 

--- a/pkg/expressions/keyBuilder.go
+++ b/pkg/expressions/keyBuilder.go
@@ -43,7 +43,7 @@ func (s *KeyBuilder) Func(name string, f KeyBuilderFunction) {
 }
 
 // Compile builds a new key-builder, returning error(s) on build issues
-// if the CompiledKeyBuilder is not nil, then something is still useable (albeit may have problems)
+// if the CompiledKeyBuilder is not nil, then something is still usable (albeit may have problems)
 func (s *KeyBuilder) Compile(template string) (*CompiledKeyBuilder, *CompilerErrors) {
 	kb := &CompiledKeyBuilder{
 		stages: make([]KeyBuilderStage, 0),

--- a/pkg/expressions/stdlib/funcs.go
+++ b/pkg/expressions/stdlib/funcs.go
@@ -16,7 +16,7 @@ var StandardFunctions = map[string]KeyBuilderFunction{
 	"isint": KeyBuilderFunction(kfIsInt),
 	"isnum": KeyBuilderFunction(kfIsNum),
 
-	// Arithmatic
+	// Arithmetic
 	"sumi":  arithmaticHelperi(func(a, b int) int { return a + b }),
 	"subi":  arithmaticHelperi(func(a, b int) int { return a - b }),
 	"multi": arithmaticHelperi(func(a, b int) int { return a * b }),

--- a/pkg/extractor/batchers/batcher.go
+++ b/pkg/extractor/batchers/batcher.go
@@ -177,7 +177,7 @@ func (s *Batcher) syncReaderToBatcher(sourceName string, reader io.Reader, batch
 }
 
 // syncReaderToBatcherWithTimeFlush is similar to `syncReaderToBatcher`, except if it gets a new line
-// it will flush the batch if n time has elapsed since the last flush, irregardless of how many items are in the current batch
+// it will flush the batch if n time has elapsed since the last flush, regardless of how many items are in the current batch
 // Good for potentially slow or more interactive workloads (tail, stdin, etc)
 func (s *Batcher) syncReaderToBatcherWithTimeFlush(sourceName string, reader io.Reader, batchSize int, autoFlush time.Duration) {
 	readerMetrics := newReaderMetrics(reader)

--- a/pkg/extractor/extractor.go
+++ b/pkg/extractor/extractor.go
@@ -86,7 +86,7 @@ func (s *extractorInstance) processLineSync(source string, lineNum uint64, line 
 		//   as a pointer instead
 		lineStringPtr := *(*string)(unsafe.Pointer(&line))
 		// A context is created for each "instance", and since a context isn't shared beyond building a key
-		//   it's significantly faster to re-use a single context per goroutine
+		//   it's significantly faster to reuse a single context per goroutine
 		expContext := s.context
 		expContext.linePtr = lineStringPtr
 		expContext.indices = matches

--- a/pkg/matchers/fastregex/pcre2.go
+++ b/pkg/matchers/fastregex/pcre2.go
@@ -149,7 +149,7 @@ func (s *pcre2Regexp) MatchString(str string) bool {
 	return rc >= 0
 }
 
-// FindSubmatchIndex, like regexp, returns a set of string indecies where the results are
+// FindSubmatchIndex, like regexp, returns a set of string indices where the results are
 // FindSubmatchIndex is NOT thread-safe.  You need to create an instance of the fastregex engine
 func (s *pcre2Regexp) FindSubmatchIndex(b []byte) []int {
 	if len(b) == 0 {

--- a/pkg/matchers/fastregex/re2.go
+++ b/pkg/matchers/fastregex/re2.go
@@ -5,7 +5,7 @@ package fastregex
 import "regexp"
 
 /*
-The fallback exposes the re2/regexp go implementaiton in the
+The fallback exposes the re2/regexp go implementation in the
 cases where we can't compile with PCRE support
 */
 

--- a/pkg/multiterm/termscaler/scale.go
+++ b/pkg/multiterm/termscaler/scale.go
@@ -49,7 +49,7 @@ func (s Scaler) remapMinMax(min, max int64) (float64, float64) {
 	return math.Floor(s.mapVal(float64(min))), math.Ceil(s.mapVal(float64(max)))
 }
 
-// Returns a val, betwen min and max, to a 0-1 float range
+// Returns a val, between min and max, to a 0-1 float range
 func (s Scaler) Scale(val, min, max int64) float64 {
 	if max < min {
 		return 0.0


### PR DESCRIPTION
Found via `codespell -L atleast,thur,confg,thar,waht,allo,tast`.