### PR TITLE
Histo sum bug for non-1 increments

### DIFF
--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -15,18 +15,21 @@ func TestCommandGetter(t *testing.T) {
 	assert.NotNil(t, GetSupportedCommands())
 }
 
+// Test all commands in a list asserting no errors
 func testCommandSet(t *testing.T, command *cli.Command, commandArgList ...string) {
 	for _, args := range commandArgList {
 		assert.NoError(t, testCommand(command, args))
 	}
 }
 
+// Tests command via testCommand, returning stdout and stderr
 func testCommandCapture(command *cli.Command, cmd string) (stdout, stderr string, err error) {
 	return testutil.Capture(func(w *os.File) error {
 		return testCommand(command, cmd)
 	})
 }
 
+// Run a command, and returns any error
 func testCommand(command *cli.Command, cmd string) error {
 	app := cli.NewApp()
 

--- a/cmd/histo.go
+++ b/cmd/histo.go
@@ -17,7 +17,7 @@ import (
 func writeHistoOutput(writer *termrenderers.HistoWriter, counter *aggregation.MatchCounter, count int, sorter sorting.NameValueSorter, atLeast int64) {
 	items := counter.ItemsSortedBy(count, sorter)
 	line := 0
-	writer.UpdateSamples(counter.Count())
+	writer.UpdateTotal(counter.Total())
 	for _, match := range items {
 		count := match.Item.Count()
 		if count >= atLeast {

--- a/cmd/histo_test.go
+++ b/cmd/histo_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Exercise common commands for panics
 func TestHistogram(t *testing.T) {
 	testCommandSet(t, histogramCommand(),
 		`-m (\d+) testdata/log.txt`,

--- a/pkg/aggregation/counter.go
+++ b/pkg/aggregation/counter.go
@@ -19,7 +19,6 @@ type MatchPair struct {
 type MatchCounter struct {
 	matches map[string]*MatchItem
 	errors  uint64
-	samples uint64
 	total   int64
 }
 
@@ -27,10 +26,6 @@ func NewCounter() *MatchCounter {
 	return &MatchCounter{
 		matches: make(map[string]*MatchItem),
 	}
-}
-
-func (s *MatchCounter) Count() uint64 {
-	return s.samples
 }
 
 func (s *MatchCounter) Total() int64 {
@@ -71,7 +66,6 @@ func (s *MatchCounter) SampleValue(element string, count int64) {
 	}
 	item.count += count
 	s.total += count
-	s.samples++
 }
 
 func (s *MatchCounter) ParseErrors() uint64 {

--- a/pkg/aggregation/counter.go
+++ b/pkg/aggregation/counter.go
@@ -20,6 +20,7 @@ type MatchCounter struct {
 	matches map[string]*MatchItem
 	errors  uint64
 	samples uint64
+	total   int64
 }
 
 func NewCounter() *MatchCounter {
@@ -30,6 +31,10 @@ func NewCounter() *MatchCounter {
 
 func (s *MatchCounter) Count() uint64 {
 	return s.samples
+}
+
+func (s *MatchCounter) Total() int64 {
+	return s.total
 }
 
 func (s *MatchCounter) GroupCount() int {
@@ -65,6 +70,7 @@ func (s *MatchCounter) SampleValue(element string, count int64) {
 		s.matches[element] = item
 	}
 	item.count += count
+	s.total += count
 	s.samples++
 }
 

--- a/pkg/aggregation/counter_test.go
+++ b/pkg/aggregation/counter_test.go
@@ -48,7 +48,6 @@ func TestInOrderItemsByKey(t *testing.T) {
 
 	assert.Equal(t, 3, len(items))
 	assert.Equal(t, 3, val.GroupCount())
-	assert.Equal(t, uint64(7), val.Count())
 	assert.Equal(t, int64(8), val.Total())
 	assert.Equal(t, uint64(1), val.ParseErrors())
 	assert.Equal(t, "abc", items[0].Name)

--- a/pkg/aggregation/counter_test.go
+++ b/pkg/aggregation/counter_test.go
@@ -49,6 +49,7 @@ func TestInOrderItemsByKey(t *testing.T) {
 	assert.Equal(t, 3, len(items))
 	assert.Equal(t, 3, val.GroupCount())
 	assert.Equal(t, uint64(7), val.Count())
+	assert.Equal(t, int64(8), val.Total())
 	assert.Equal(t, uint64(1), val.ParseErrors())
 	assert.Equal(t, "abc", items[0].Name)
 	assert.Equal(t, int64(3), items[0].Item.Count())

--- a/pkg/multiterm/termrenderers/histoWriter.go
+++ b/pkg/multiterm/termrenderers/histoWriter.go
@@ -19,7 +19,7 @@ type histoPair struct {
 type HistoWriter struct {
 	writer      multiterm.MultilineTerm
 	maxVal      int64
-	samples     uint64
+	total       int64
 	textSpacing int
 	items       []histoPair
 
@@ -76,8 +76,8 @@ func (s *HistoWriter) WriteForLine(line int, key string, val int64) {
 	}
 }
 
-func (s *HistoWriter) UpdateSamples(samples uint64) {
-	s.samples = samples
+func (s *HistoWriter) UpdateTotal(total int64) {
+	s.total = total
 	s.fullRender()
 }
 
@@ -96,8 +96,8 @@ func (s *HistoWriter) writeLine(line int, key string, val int64) {
 	sb.WriteString(color.Wrapf(color.Yellow, "%-[2]*[1]s", key, s.textSpacing))
 	sb.WriteString("    ")
 	fmt.Fprintf(&sb, "%-10s", s.Formatter(val, 0, s.maxVal))
-	if s.ShowPercentage && s.samples > 0 {
-		percentage := float64(val) / float64(s.samples)
+	if s.ShowPercentage && s.total > 0 {
+		percentage := float64(val) / float64(s.total)
 		sb.WriteString(" ")
 		sb.WriteString(color.Wrapf(color.Cyan, "[%4.1f%%]", percentage*100.0))
 	}

--- a/pkg/multiterm/termrenderers/histoWriter_test.go
+++ b/pkg/multiterm/termrenderers/histoWriter_test.go
@@ -13,7 +13,7 @@ func TestBasicHisto(t *testing.T) {
 	mt := NewHistogram(vt, 5)
 
 	termunicode.UnicodeEnabled = false
-	mt.UpdateSamples(10000)
+	mt.UpdateTotal(10000)
 	mt.WriteForLine(1, "key", 1000)
 	mt.WriteFooter(0, "hello")
 	termunicode.UnicodeEnabled = true


### PR DESCRIPTION
Percentages are displayed incorrectly when histogram is incremented by non-1