### PR TITLE
Disable bounds check, save 5-10% cpu

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -19,6 +19,8 @@ builds:
     - -s -w
     - -X main.version={{.Version}}
     - -X main.buildSha={{.ShortCommit}}
+  gcflags:
+    - -B
   goarch:
     - amd64
   goos:
@@ -35,6 +37,8 @@ builds:
     - -s -w
     - -X main.version={{.Version}}
     - -X main.buildSha={{.ShortCommit}}
+  gcflags:
+    - -B
   goarch:
     - amd64
     - arm64

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -37,6 +37,11 @@ tasks:
       - mv -f pgogen.cpu.prof default.pgo
       - task: build
 
+  build:snapshot:
+    desc: Builds snapshots via goreleaser
+    cmds:
+      - goreleaser release --snapshot --clean
+
   # Test
   test:unit:
     desc: Run all tests


### PR DESCRIPTION
Doesn't expect any bounds overflows in a normal situation, which would panic anyway. This will just lead to unpredictable behavior, but is still isolated in the process.  Vulnerabilities could exist, but since this is likely used as a tool anyway, may be worth the improvements.

I'll leave this open for a bit, not sure if I'll merge it yet.